### PR TITLE
[TEST] chore(ci/hax): update github action to hax ref 533f870

### DIFF
--- a/.github/workflows/hax.yml
+++ b/.github/workflows/hax.yml
@@ -15,7 +15,7 @@ jobs:
         uses: hacspec/hax-actions@main
         with:
           # pin hax to known-working
-          hax_reference: d10f891a19f96bcafa9e31b1d78763e4f3cf30b4
+          hax_reference: 533f87048f68705e8884ff9516db1371e8a2773d
 
       - name: 🏃 Extract `riot-rs-runqueue`
         working-directory: ./src/riot-rs-runqueue


### PR DESCRIPTION
Test if hax CI action passes for RIOT-rs if we update to their most recent main.